### PR TITLE
fix: stub HTMLCanvasElement.getContext in test setup to silence jsdom warnings

### DIFF
--- a/src/test-setup.ts
+++ b/src/test-setup.ts
@@ -36,3 +36,36 @@ Object.defineProperty(globalThis, 'ResizeObserver', {
   configurable: true,
   value: MockResizeObserver,
 })
+
+// HTMLCanvasElement.getContext is not implemented in jsdom — stub it with a
+// no-op 2D context so canvas-drawing code (WaveformCanvas, useVideoThumbnails)
+// doesn't throw during tests.
+HTMLCanvasElement.prototype.getContext = function () {
+  return {
+    clearRect: () => {},
+    fillRect: () => {},
+    strokeRect: () => {},
+    beginPath: () => {},
+    moveTo: () => {},
+    lineTo: () => {},
+    stroke: () => {},
+    fill: () => {},
+    arc: () => {},
+    save: () => {},
+    restore: () => {},
+    scale: () => {},
+    translate: () => {},
+    drawImage: () => {},
+    getImageData: () => ({ data: new Uint8ClampedArray(0) }),
+    putImageData: () => {},
+    createImageData: () => ({ data: new Uint8ClampedArray(0) }),
+    setTransform: () => {},
+    canvas: this,
+    fillStyle: '',
+    strokeStyle: '',
+    lineWidth: 1,
+    font: '',
+    textAlign: 'start' as CanvasTextAlign,
+    globalAlpha: 1,
+  } as unknown as CanvasRenderingContext2D
+}


### PR DESCRIPTION
## Summary
- jsdom doesn't implement `HTMLCanvasElement.prototype.getContext`, causing ~30+ \"Not implemented\" errors to flood the test output on every run
- Both `WaveformCanvas.tsx` and `useVideoThumbnails.ts` call `canvas.getContext('2d')` at render/call time, triggering the warning across most test suites
- Added a no-op 2D context stub in `src/test-setup.ts` (alongside existing Worker and ResizeObserver stubs) to suppress all of them

## Test plan
- [ ] Run `pnpm test` — all 361 tests pass, zero canvas-related warnings in output

🤖 Generated with [Claude Code](https://claude.com/claude-code)